### PR TITLE
Add `pre-commit` hook definition

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: squabble
+  name: squabble
+  description: "squabble: An extensible linter for SQL queries and migrations."
+  entry: squabble
+  language: python
+  language_version: python3
+  types: [sql]


### PR DESCRIPTION
Adds a [`pre-commit`](https://pre-commit.com) hook definition. 

With kind regards,
Philip Trauner