### PR TITLE
Add `squabble-disable` to prevent squabble from running on a file.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,25 @@
 Changelog
 =========
 
+v1.4.0 (unreleased)
+-------------------
+
+New
+~~~
+
+- Added `precommit <https://pre-commit.com/>`__ hook definition (Thanks
+  @PhilipTrauner!)
+- Added ``squabble-disable`` configuration to disable all lint checks for a
+  file.
+
+Changes
+~~~~~~~
+
+- Per-file configuration is now done using ``squabble-enable:rule`` and
+  ``squabble-disable:rule``. The original ``enable:rule`` format will continue
+  to be supported, but is deprecated.
+
+
 v1.3.3 (2019-08-27)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,11 @@ this could be done:
    -- squabble-enable:RuleB config=value array=1,2,3
    SELECT email FROM users WHERE ...;
 
+To prevent squabble from running on a file, use ``-- squabble-disable``. Note
+that this will also disable syntax checking. Note that this flag will take
+precedence over any other configuration set either on the command line or in
+the rest of the file.
+
 
 Example Configuration
 ~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -87,15 +87,15 @@ Per-File Configuration
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Configuration can also be applied at the file level by using SQL line comments
-in the form ``-- enable:RuleName`` or ``-- disable:RuleName``.
+in the form ``-- squabble-enable:RuleName`` or ``-- squabble-disable:RuleName``.
 
 For example, to disable ``RuleA`` and enable ``RuleB`` just for one file,
 this could be done:
 
 .. code-block:: sql
 
-   -- disable:RuleA
-   -- enable:RuleB config=value array=1,2,3
+   -- squabble-disable:RuleA
+   -- squabble-enable:RuleB config=value array=1,2,3
    SELECT email FROM users WHERE ...;
 
 

--- a/squabble/cli.py
+++ b/squabble/cli.py
@@ -106,6 +106,8 @@ def run_linter(base_config, paths, expanded):
     issues = []
     for file_name, contents in files:
         file_config = config.apply_file_config(base_config, contents)
+        if file_config is None:
+            continue
         issues += lint.check_file(file_config, file_name, contents)
 
     reporter.report(base_config.reporter, issues, dict(files))

--- a/squabble/config.py
+++ b/squabble/config.py
@@ -198,11 +198,16 @@ def apply_file_config(base, contents):
     Given a base configuration object and the contents of a file,
     return a new config that applies any file-specific rule
     additions/deletions.
+
+    Returns ``None`` if the file should be skipped.
     """
     # Operate on a copy so we don't mutate the base config
     file_rules = copy.deepcopy(base.rules)
 
     rules = _extract_file_rules(contents)
+
+    if rules['skip_file']:
+        return None
 
     for rule, opts in rules['enable'].items():
         file_rules[rule] = opts
@@ -224,10 +229,16 @@ def _extract_file_rules(text):
     []
     >>> r['enable']
     {'rule1': {'arr': ['a', 'b', 'c']}}
+    >>> r['skip_file']
+    False
+    >>> r = _extract_file_rules('-- squabble-disable')
+    >>> r['skip_file']
+    True
     """
     rules = {
         'enable': {},
         'disable': [],
+        'skip_file': False
     }
 
     comment_re = re.compile(
@@ -245,7 +256,10 @@ def _extract_file_rules(text):
 
         action, rule, opts = m.groups()
 
-        if action == 'disable':
+        if action == 'disable' and not rule:
+            rules['skip_file'] = True
+
+        elif action == 'disable':
             rules['disable'].append(rule)
 
         elif action == 'enable':

--- a/squabble/config.py
+++ b/squabble/config.py
@@ -219,10 +219,10 @@ def _extract_file_rules(text):
 
     Valid lines are SQL line comments that enable or disable specific rules.
 
-    >>> rules = _extract_file_rules('-- enable:rule1 arr=a,b,c')
-    >>> rules['disable']
+    >>> r = _extract_file_rules('-- squabble-enable:rule1 arr=a,b,c')
+    >>> r['disable']
     []
-    >>> rules['enable']
+    >>> r['enable']
     {'rule1': {'arr': ['a', 'b', 'c']}}
     """
     rules = {
@@ -230,7 +230,11 @@ def _extract_file_rules(text):
         'disable': [],
     }
 
-    comment_re = re.compile(r'--\s*(enable|disable):(\w+)(.*?)$', re.I)
+    comment_re = re.compile(
+        r'--\s*'
+        r'(?:squabble-)?(enable|disable)'
+        r'(?::\s*(\w+)(.*?))?'
+        r'$', re.I)
 
     for line in text.splitlines():
         line = line.strip()

--- a/tests/sql/add_column_disallow_constraints.sql
+++ b/tests/sql/add_column_disallow_constraints.sql
@@ -1,4 +1,4 @@
--- enable:AddColumnDisallowConstraints disallowed=DEFAULT,FOREIGN
+-- squabble-enable:AddColumnDisallowConstraints disallowed=DEFAULT,FOREIGN
 -- >>> {"line": 4, "column": 46, "message_id": "ConstraintNotAllowed"}
 
 ALTER TABLE foobar ADD COLUMN colname coltype DEFAULT baz;

--- a/tests/sql/disallow_change_column_type.sql
+++ b/tests/sql/disallow_change_column_type.sql
@@ -1,4 +1,4 @@
--- enable:DisallowChangeColumnType
+-- squabble-enable:DisallowChangeColumnType
 -- >>> {"line": 4, "column": 47, "message_id": "ChangeTypeNotAllowed"}
 
 ALTER TABLE foo ALTER COLUMN bar SET DATA TYPE baz;

--- a/tests/sql/disallow_float_types.sql
+++ b/tests/sql/disallow_float_types.sql
@@ -1,4 +1,4 @@
--- enable:DisallowFloatTypes
+-- squabble-enable:DisallowFloatTypes
 -- >>> {"line": 8,  "column": 2, "message_id": "LossyFloatType"}
 -- >>> {"line": 9,  "column": 2, "message_id": "LossyFloatType"}
 -- >>> {"line": 15, "column": 2, "message_id": "LossyFloatType"}

--- a/tests/sql/disallow_foreign_key.sql
+++ b/tests/sql/disallow_foreign_key.sql
@@ -1,4 +1,4 @@
--- enable:DisallowForeignKey excluded=fk_allowed,new_table
+-- squabble-enable:DisallowForeignKey excluded=fk_allowed,new_table
 -- >>> {"line": 7, "column": 47, "message_id": "DisallowedForeignKeyConstraint", "message_params": {"table": "foreign_key_reference"}}
 -- >>> {"line": 8, "column": 53, "message_id": "DisallowedForeignKeyConstraint", "message_params": {"table": "inline_foreign_key_reference"}}
 -- >>> {"line": 9, "column": 42, "message_id": "DisallowedForeignKeyConstraint", "message_params": {"table": "alter_table_with_fk_later"}}

--- a/tests/sql/disallow_not_in.sql
+++ b/tests/sql/disallow_not_in.sql
@@ -1,4 +1,4 @@
--- enable:DisallowNotIn
+-- squabble-enable:DisallowNotIn
 -- >>> {"line": 8, "column": 17, "message_id": "NotInNotAllowed"}
 -- >>> {"line": 12, "column": 9, "message_id": "NotInNotAllowed"}
 

--- a/tests/sql/disallow_padded_char_type.sql
+++ b/tests/sql/disallow_padded_char_type.sql
@@ -1,4 +1,4 @@
--- enable:DisallowPaddedCharType
+-- squabble-enable:DisallowPaddedCharType
 -- >>> {"line": 13, "column": 2, "message_id": "WastefulCharType"}
 -- >>> {"line": 14, "column": 2, "message_id": "WastefulCharType"}
 -- >>> {"line": 22, "column": 13, "message_id": "WastefulCharType"}

--- a/tests/sql/disallow_rename_enum_value.sql
+++ b/tests/sql/disallow_rename_enum_value.sql
@@ -1,4 +1,4 @@
--- enable:DisallowRenameEnumValue
+-- squabble-enable:DisallowRenameEnumValue
 -- >>> {"message_id": "RenameNotAllowed"}
 
 ALTER TYPE this_is_fine ADD VALUE '!!!';

--- a/tests/sql/disallow_timestamp_precision.sql
+++ b/tests/sql/disallow_timestamp_precision.sql
@@ -1,4 +1,4 @@
--- enable:DisallowTimestampPrecision allow_precision_greater_than=5
+-- squabble-enable:DisallowTimestampPrecision allow_precision_greater_than=5
 -- >>> {"line": 24, "column": 6, "message_id": "NoTimestampPrecision"}
 -- >>> {"line": 25, "column": 6, "message_id": "NoTimestampPrecision"}
 -- >>> {"line": 26, "column": 6, "message_id": "NoTimestampPrecision"}

--- a/tests/sql/disallow_timetz_types.sql
+++ b/tests/sql/disallow_timetz_types.sql
@@ -1,4 +1,4 @@
--- enable:DisallowTimetzType
+-- squabble-enable:DisallowTimetzType
 -- >>> {"line": 15, "column": 6, "message_id": "NoTimetzType"}
 -- >>> {"line": 16, "column": 6, "message_id": "NoTimetzType"}
 -- >>> {"line": 24, "column": 2, "message_id": "NoCurrentTime"}

--- a/tests/sql/require_columns.sql
+++ b/tests/sql/require_columns.sql
@@ -1,4 +1,4 @@
--- enable:RequireColumns required="created_at,timestamp with time zone","updated_at"
+-- squabble-enable:RequireColumns required="created_at,timestamp with time zone","updated_at"
 -- >>> {"line": 10, "column": 13, "message_id": "MissingRequiredColumn", "message_params": {"tbl": "missing_columns", "col": "updated_at"}}
 -- >>> {"line": 15, "column": 2, "message_id": "ColumnWrongType", "message_params": {"tbl": "type_mismatch", "col": "created_at", "actual": "integer", "required": "timestamp with time zone"}}
 

--- a/tests/sql/require_concurrent_index.sql
+++ b/tests/sql/require_concurrent_index.sql
@@ -1,4 +1,4 @@
--- enable:RequireConcurrentIndex
+-- squabble-enable:RequireConcurrentIndex
 -- >>> {"line": 10, "column": 24, "message_id": "IndexNotConcurrent"}
 
 CREATE TABLE foo(id uuid);

--- a/tests/sql/require_foreign_key.sql
+++ b/tests/sql/require_foreign_key.sql
@@ -1,4 +1,4 @@
--- enable:RequireForeignKey
+-- squabble-enable:RequireForeignKey
 -- >>> {"line": 12, "column": 24, "message_id": "MissingForeignKeyConstraint"}
 -- >>> {"line": 19, "column": 46, "message_id": "MissingForeignKeyConstraint"}
 CREATE TABLE empty ();

--- a/tests/sql/require_primary_key.sql
+++ b/tests/sql/require_primary_key.sql
@@ -1,4 +1,4 @@
--- enable:RequirePrimaryKey
+-- squabble-enable:RequirePrimaryKey
 -- >>> {"line": 14, "column": 13, "message_id": "MissingPrimaryKey"}
 
 CREATE TABLE inline_pk(


### PR DESCRIPTION
Taking a crack at @PhilipTrauner's idea from #6. 

This adds support for a new per-file configuration option, which can turn off any syntax/semantic checking for an entire file.

Additionally, this PR updates the per-file configuration keys to use the prefix `squabble-`.

```sql
/* old format (deprecated, but still supported) */
-- enable:ruleA

/* new format */
-- squabble-enable:ruleA
```