### PR TITLE
Line-based ignores

### DIFF
--- a/squabble/cli.py
+++ b/squabble/cli.py
@@ -106,7 +106,8 @@ def run_linter(base_config, paths, expanded):
     issues = []
     for file_name, contents in files:
         file_config = config.apply_file_config(base_config, file_name, contents)
-        if file_config is None:
+        # The file should be skipped if no specific line is ignored
+        if file_config.skip.get(file_name) == []:
             continue
         issues += lint.check_file(file_config, file_name, contents)
 

--- a/squabble/cli.py
+++ b/squabble/cli.py
@@ -105,7 +105,7 @@ def run_linter(base_config, paths, expanded):
 
     issues = []
     for file_name, contents in files:
-        file_config = config.apply_file_config(base_config, contents)
+        file_config = config.apply_file_config(base_config, file_name, contents)
         if file_config is None:
             continue
         issues += lint.check_file(file_config, file_name, contents)

--- a/squabble/config.py
+++ b/squabble/config.py
@@ -15,7 +15,8 @@ logger = logging.getLogger(__name__)
 Config = collections.namedtuple('Config', [
     'reporter',
     'plugins',
-    'rules'
+    'rules',
+    'skip'
 ])
 
 
@@ -23,7 +24,8 @@ Config = collections.namedtuple('Config', [
 DEFAULT_CONFIG = dict(
     reporter='plain',
     plugins=[],
-    rules={}
+    rules={},
+    skip={}
 )
 
 PRESETS = {
@@ -189,7 +191,8 @@ def load_config(config_file, preset_names=None, reporter_name=None):
     return Config(
         reporter=reporter_name or config.get('reporter', base.reporter),
         plugins=config.get('plugins', base.plugins),
-        rules=rules
+        rules=rules,
+        skip=config.get('skip', {})
     )
 
 

--- a/squabble/lint.py
+++ b/squabble/lint.py
@@ -13,7 +13,10 @@ _LintIssue = collections.namedtuple('_LintIssue', [
     'node',
     'file',
     'severity',
-    'location'
+    'line_text',
+    'line',
+    'column',
+    'abs_location'
 ])
 
 # Make all the fields nullable

--- a/squabble/reporter.py
+++ b/squabble/reporter.py
@@ -116,7 +116,7 @@ _COLOR_FORMAT = '{bold}{{file}}:{reset}{{line}}:{{column}}{reset} '\
 @reporter("plain")
 def plain_text_reporter(issue, file_contents):
     """Simple single-line output format that is easily parsed by editors."""
-    info = _issue_info(issue, file_contents)
+    info = _issue_info(issue)
     return [
         _SIMPLE_FORMAT.format(**info)
     ]
@@ -136,7 +136,7 @@ def color_reporter(issue, file_contents):
     Extension of :func:`squabble.reporter.plain_text_reporter`, uses
     ANSI color and shows error location.
     """
-    info = _issue_info(issue, file_contents)
+    info = _issue_info(issue)
     info['severity'] = '{color}{severity}{reset}'.format(
         color=_SEVERITY_COLOR[issue.severity],
         severity=issue.severity.name,
@@ -194,7 +194,7 @@ def sqlint_reporter(issue, file_contents):
 
     error_level = {Severity.HIGH, Severity.CRITICAL}
 
-    info = _issue_info(issue, file_contents)
+    info = _issue_info(issue)
     info['severity'] = 'ERROR' if issue.severity in error_level else 'WARNING'
 
     return [

--- a/squabble/reporter.py
+++ b/squabble/reporter.py
@@ -82,62 +82,6 @@ def report(reporter_name, issues, files):
             _print_err(line)
 
 
-def _location_for_issue(issue):
-    """
-    Return the offset into the file for this issue, or None if it
-    cannot be determined.
-    """
-    if issue.node and issue.node.location != pglast.Missing:
-        return issue.node.location.value
-
-    return issue.location
-
-
-def _issue_to_file_location(issue, contents):
-    """
-    Given an issue (which may or may not have a :class:`pglast.Node` with a
-    ``location`` field) and the contents of the file containing that
-    node, return the ``(line_str, line, column)`` that node is located at,
-    or ``('', 1, 0)``.
-
-    :param issue:
-    :type issue: :class:`squabble.lint.LintIssue`
-    :param contents: Full contents of the file being linted, as a string.
-    :type contents: str
-
-    >>> from squabble.lint import LintIssue
-
-    >>> issue = LintIssue(location=8, file='foo')
-    >>> sql = '1234\\n678\\nABCD'
-    >>> _issue_to_file_location(issue, sql)
-    ('678', 2, 3)
-
-    >>> issue = LintIssue(location=7, file='foo')
-    >>> sql = '1\\r\\n\\r\\n678\\r\\nBCD'
-    >>> _issue_to_file_location(issue, sql)
-    ('678', 3, 2)
-    """
-    loc = _location_for_issue(issue)
-
-    if loc is None or loc >= len(contents):
-        return ('', 1, 0)
-
-    # line number is number of newlines in the file before this
-    # location, 1 indexed.
-    line_num = contents[:loc].count('\n') + 1
-
-    # Search forwards/backwards for the first newline before and first
-    # newline after this point.
-    line_start = contents.rfind('\n', 0, loc) + 1
-    line_end = contents.find('\n', loc)
-
-    # Strip out \r so we can treat \r\n and \n the same way
-    line = contents[line_start:line_end].replace('\r', '')
-    column = loc - line_start
-
-    return(line, line_num, column)
-
-
 def _print_err(msg):
     print(msg, file=sys.stderr)
 

--- a/squabble/reporter.py
+++ b/squabble/reporter.py
@@ -149,17 +149,13 @@ def _format_message(issue):
     return issue.message.format()
 
 
-def _issue_info(issue, file_contents):
+def _issue_info(issue):
     """Return a dictionary of metadata for an issue."""
-    line, line_num, column = _issue_to_file_location(issue, file_contents)
     formatted = _format_message(issue)
 
     return {
         **issue._asdict(),
         **(issue.message.asdict() if issue.message else {}),
-        'line_text': line,
-        'line': line_num,
-        'column': column,
         'message_formatted': formatted,
         'severity': issue.severity.name,
     }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -77,7 +77,7 @@ def test_apply_file_config(mock_extract):
         'skip_file': False
     }
 
-    orig = config.Config(reporter='', plugins=[], rules={'foo': {}, 'bar': {}})
+    orig = config.Config(reporter='', plugins=[], rules={'foo': {}, 'bar': {}}, skip={})
     base = copy.deepcopy(orig)
 
     modified = config.apply_file_config(base, 'file_name')
@@ -96,12 +96,12 @@ def test_apply_file_config_with_skip_file(mock_extract):
         'skip_file': True
     }
 
-    orig = config.Config(reporter='', plugins=[], rules={})
+    orig = config.Config(reporter='', plugins=[], rules={}, skip={'file_name': []})
     base = copy.deepcopy(orig)
 
     modified = config.apply_file_config(base, 'file_name')
 
-    assert modified is None
+    assert modified.skip == {'file_name': []}
 
 
 @patch('squabble.config._get_vcs_root')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,7 +19,8 @@ bar
     expected = {
         'enable': {'foo': {'k1': 'v1', 'k2': 'v2'}},
         'disable': ['abc'],
-        'skip_file': False
+        'skip_file': False,
+        'skip_lines': []
     }
 
     assert expected == rules
@@ -39,7 +40,8 @@ bar
     expected = {
         'enable': {'foo': {'k1': 'v1', 'k2': 'v2'}},
         'disable': ['abc'],
-        'skip_file': True
+        'skip_file': True,
+        'skip_lines': []
     }
 
     assert expected == rules
@@ -74,7 +76,8 @@ def test_apply_file_config(mock_extract):
     mock_extract.return_value = {
         'enable': {'baz': {'a': 1}},
         'disable': ['bar'],
-        'skip_file': False
+        'skip_file': False,
+        'skip_lines': []
     }
 
     orig = config.Config(reporter='', plugins=[], rules={'foo': {}, 'bar': {}}, skip={})
@@ -93,7 +96,8 @@ def test_apply_file_config_with_skip_file(mock_extract):
     mock_extract.return_value = {
         'enable': {},
         'disable': [],
-        'skip_file': True
+        'skip_file': True,
+        'skip_lines': []
     }
 
     orig = config.Config(reporter='', plugins=[], rules={}, skip={'file_name': []})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -83,7 +83,7 @@ def test_apply_file_config(mock_extract):
     orig = config.Config(reporter='', plugins=[], rules={'foo': {}, 'bar': {}}, skip={})
     base = copy.deepcopy(orig)
 
-    modified = config.apply_file_config(base, 'file_name')
+    modified = config.apply_file_config(base, 'file_name', 'file_name')
 
     assert modified.rules == {'foo': {}, 'baz': {'a': 1}}
 
@@ -103,7 +103,7 @@ def test_apply_file_config_with_skip_file(mock_extract):
     orig = config.Config(reporter='', plugins=[], rules={}, skip={'file_name': []})
     base = copy.deepcopy(orig)
 
-    modified = config.apply_file_config(base, 'file_name')
+    modified = config.apply_file_config(base, 'file_name', 'file_name')
 
     assert modified.skip == {'file_name': []}
 

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -42,7 +42,7 @@ def test_snapshot(file_name):
         pytest.skip('no output configured')
 
     base_cfg = config.get_base_config()
-    cfg = config.apply_file_config(base_cfg, contents)
+    cfg = config.apply_file_config(base_cfg, file_name, contents)
 
     issues = lint.check_file(cfg, file_name, contents)
 
@@ -74,7 +74,7 @@ def test_reporter_sanity(reporter_name):
             contents = fp.read()
             files[file_name] = contents
 
-        cfg = config.apply_file_config(base_cfg, contents)
+        cfg = config.apply_file_config(base_cfg, file_name, contents)
         issues.extend(lint.check_file(cfg, file_name, contents))
 
     reporter.report(reporter_name, issues, files)

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -49,7 +49,7 @@ def test_snapshot(file_name):
     assert len(issues) == len(expected)
 
     for i, e in zip(issues, expected):
-        info = reporter._issue_info(i, contents)
+        info = reporter._issue_info(i)
         actual = {
             k: info.get(k)
             for k in e.keys()


### PR DESCRIPTION
Adds line-based ignores as discussed in #7.

```
create table customer (
    name text not null,
    -- squabble-disable-next-line
    primary key(name)
);
```

I didn't bother to write tests for this yet, as I feel that I made some rather substantial changes to the codebase that you might not agree with 😅 

Adds the `skip` attribute to the global config that can either be set through the global configuration, or by the per-file configuration system (which is much more likely).